### PR TITLE
Add `options` parameter to start_firefox(...)

### DIFF
--- a/helium/__init__.py
+++ b/helium/__init__.py
@@ -40,12 +40,14 @@ __all__ = [
 	'SPACE', 'SUBTRACT', 'TAB', 'UP'
 ]
 
-def start_firefox(url=None, headless=False):
+def start_firefox(url=None, headless=False, options=None):
 	"""
 	:param url: URL to open.
 	:type url: str
 	:param headless: Whether to start Firefox in headless mode.
 	:type headless: bool
+	:param options: FirefoxOptions to use for starting the browser.
+	:type options: :py:class:`selenium.webdriver.FirefoxOptions`
 
 	Starts an instance of Firefox. You can optionally open a URL::
 
@@ -58,6 +60,14 @@ def start_firefox(url=None, headless=False):
 		start_firefox(headless=True)
 		start_firefox("google.com", headless=True)
 
+	For more advanced configuration, use the `options` parameter::
+
+		from selenium.webdriver import FirefoxOptions
+		options = FirefoxOptions()
+		options.add_argument("--width=2560")
+		options.add_argument("--height=1440")
+		start_firefox(options=options)
+
 	On shutdown of the Python interpreter, Helium cleans up all resources used
 	for controlling the browser (such as the geckodriver process), but does
 	not close the browser itself. If you want to terminate the browser at the
@@ -65,7 +75,7 @@ def start_firefox(url=None, headless=False):
 
 		kill_browser()
 	"""
-	return _get_api_impl().start_firefox_impl(url, headless)
+	return _get_api_impl().start_firefox_impl(url, headless, options)
 
 def start_chrome(url=None, headless=False, options=None):
 	"""

--- a/helium/_impl/__init__.py
+++ b/helium/_impl/__init__.py
@@ -74,17 +74,17 @@ class APIImpl:
 		" * set_driver(...)"
 	def __init__(self):
 		self.driver = None
-	def start_firefox_impl(self, url=None, headless=False):
-		firefox_driver = self._start_firefox_driver(headless)
+	def start_firefox_impl(self, url=None, headless=False, options=None):
+		firefox_driver = self._start_firefox_driver(headless, options)
 		return self._start(firefox_driver, url)
-	def _start_firefox_driver(self, headless):
-		firefox_options = self._get_firefox_options(headless)
+	def _start_firefox_driver(self, headless, options):
+		firefox_options = self._get_firefox_options(headless, options)
 		kwargs = self._get_firefox_driver_kwargs(firefox_options)
 		result = Firefox(**kwargs)
 		atexit.register(self._kill_service, result.service)
 		return result
-	def _get_firefox_options(self, headless):
-		result = FirefoxOptions()
+	def _get_firefox_options(self, headless, options):
+		result = FirefoxOptions() if options is None else options
 		if headless:
 			result.headless = True
 		return result


### PR DESCRIPTION
https://github.com/mherrmann/selenium-python-helium/issues/19#issuecomment-617803108
>Regarding your question: Helium lets you supply `ChromeOptions` to `start_chrome` since the [last release](https://github.com/mherrmann/selenium-python-helium/releases/tag/v3.0.2). Maybe something similar could be added for Firefox?

I implemented with reference to https://github.com/mherrmann/selenium-python-helium/commit/3e2f9f2ee8e2d38d1937c9b38be65ee50bd0e81e so that `FirefoxOptions` can be passed.