### PR TITLE
Added get_attribute to elements with tests.

### DIFF
--- a/helium/__init__.py
+++ b/helium/__init__.py
@@ -603,6 +603,16 @@ class HTMLElement(GUIElement):
 		The Selenium WebElement corresponding to this element.
 		"""
 		return self._impl.web_element
+	def get_attribute(self, name):
+		"""
+		Returns the value of a specific attribute of this element
+		:param name: the name of attribute to check
+		:return: the value of the attribute (or None)
+		"""
+		try:
+			return self.web_element.get_attribute(name)
+		except LookupError:
+			return None
 	def __repr__(self):
 		if self._is_bound():
 			element_html = self.web_element.get_attribute('outerHTML')

--- a/tests/api/test_gui_elements.py
+++ b/tests/api/test_gui_elements.py
@@ -270,3 +270,9 @@ class GUIElementsTest(BrowserAT):
 		text_field = TextField("Language")
 		combo_box = ComboBox("Language")
 		self.assertNotEqual(text_field.y, combo_box.y)
+	def test_html_element_get_attribute(self):
+		text_field = TextField("Example Text Field")
+		self.assertEqual("text", text_field.get_attribute("type"))
+		self.assertEqual("exampleTextFieldName", text_field.get_attribute("name"))
+		self.assertEqual("exampleTextFieldClass", text_field.get_attribute("class"))
+		self.assertEqual(None, text_field.get_attribute("nonexistent"))


### PR DESCRIPTION
Found myself wanting to test that an input had changed type on the page and thought it might be useful if we could access html attributes from elements. Tests passing (skipping some when using firefox driver).

![helium_pass](https://user-images.githubusercontent.com/20504052/94780061-c1cce680-03bf-11eb-9e05-014412add26a.png)
