### PR TITLE
Added profile param for start_firefox

### DIFF
--- a/helium/__init__.py
+++ b/helium/__init__.py
@@ -77,7 +77,7 @@ def start_chrome(
 		url, headless, maximize, options, capabilities
 	)
 
-def start_firefox(url=None, headless=False, options=None):
+def start_firefox(url=None, headless=False, options=None, profile=None):
 	"""
 	:param url: URL to open.
 	:type url: str
@@ -85,6 +85,8 @@ def start_firefox(url=None, headless=False, options=None):
 	:type headless: bool
 	:param options: FirefoxOptions to use for starting the browser.
 	:type options: :py:class:`selenium.webdriver.FirefoxOptions`
+	:param profile: FirefoxProfile to use for starting the browser.
+	:type profile: :py:class:`selenium.webdriver.FirefoxProfile`
 
 	Starts an instance of Firefox::
 
@@ -112,6 +114,23 @@ def start_firefox(url=None, headless=False, options=None):
 		options.add_argument("--height=1440")
 		start_firefox(options=options)
 
+	To set proxy, useragent, etc. (ie. things you find in about:config), use the `profile` parameter::
+
+		from selenium.webdriver import FirefoxProfile
+		profile = FirefoxProfile()
+		SOCKS5_PROXY_HOST = "0.0.0.0"
+		PROXY_PORT = 0
+		profile.set_preference("network.proxy.type", 1)
+		profile.set_preference("network.proxy.socks", SOCKS5_PROXY_HOST)
+		profile.set_preference("network.proxy.socks_port", PROXY_PORT)
+		profile.set_preference("network.proxy.socks_remote_dns", True)
+		profile.set_preference("network.proxy.socks_version", 5)
+		profile.set_preference("network.proxy.no_proxies_on", "localhost, 10.20.30.40")
+		USER_AGENT = "Mozilla/5.0 ..."
+		profile.set_preference("general.useragent.override", USER_AGENT)
+		start_firefox(profile=profile)
+
+
 	On shutdown of the Python interpreter, Helium cleans up all resources used
 	for controlling the browser (such as the geckodriver process), but does
 	not close the browser itself. If you want to terminate the browser at the
@@ -119,7 +138,7 @@ def start_firefox(url=None, headless=False, options=None):
 
 		kill_browser()
 	"""
-	return _get_api_impl().start_firefox_impl(url, headless, options)
+	return _get_api_impl().start_firefox_impl(url, headless, options, profile)
 
 def go_to(url):
 	"""

--- a/helium/_impl/__init__.py
+++ b/helium/_impl/__init__.py
@@ -16,7 +16,7 @@ from selenium.common.exceptions import UnexpectedAlertPresentException, \
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support.ui import Select
-from selenium.webdriver import Chrome, ChromeOptions, Firefox, FirefoxOptions
+from selenium.webdriver import Chrome, ChromeOptions, Firefox, FirefoxOptions, FirefoxProfile
 from time import sleep, time
 
 import atexit
@@ -74,15 +74,17 @@ class APIImpl:
 		" * set_driver(...)"
 	def __init__(self):
 		self.driver = None
-	def start_firefox_impl(self, url=None, headless=False, options=None):
-		firefox_driver = self._start_firefox_driver(headless, options)
+	def start_firefox_impl(self, url=None, headless=False, options=None, profile=None):
+		firefox_driver = self._start_firefox_driver(headless, options, profile)
 		return self._start(firefox_driver, url)
-	def _start_firefox_driver(self, headless, options):
+	def _start_firefox_driver(self, headless, options, profile):
 		firefox_options = FirefoxOptions() if options is None else options
+		firefox_profile = FirefoxProfile() if profile is None else profile
 		if headless:
 			firefox_options.headless = True
 		kwargs = {
 			'options': firefox_options,
+			'firefox_profile': firefox_profile,
 			'service_log_path': 'nul' if is_windows() else '/dev/null'
 		}
 		try:


### PR DESCRIPTION
Added the ability to set profile variables when starting up Firefox.
Example also added in `start_firefox` for setting a Socks5 proxy and a custom useragent.