### PR TITLE
Install addons/extensions

### DIFF
--- a/helium/__init__.py
+++ b/helium/__init__.py
@@ -77,7 +77,7 @@ def start_chrome(
 		url, headless, maximize, options, capabilities
 	)
 
-def start_firefox(url=None, headless=False, options=None):
+def start_firefox(url=None, headless=False, options=None, profile=None):
 	"""
 	:param url: URL to open.
 	:type url: str
@@ -85,6 +85,8 @@ def start_firefox(url=None, headless=False, options=None):
 	:type headless: bool
 	:param options: FirefoxOptions to use for starting the browser.
 	:type options: :py:class:`selenium.webdriver.FirefoxOptions`
+	:param profile: FirefoxProfile to use for starting the browser.
+	:type profile: :py:class:`selenium.webdriver.FirefoxProfile`
 
 	Starts an instance of Firefox::
 
@@ -112,6 +114,23 @@ def start_firefox(url=None, headless=False, options=None):
 		options.add_argument("--height=1440")
 		start_firefox(options=options)
 
+	To set proxy, useragent, etc. (ie. things you find in about:config), use the `profile` parameter::
+
+		from selenium.webdriver import FirefoxProfile
+		profile = FirefoxProfile()
+		SOCKS5_PROXY_HOST = "0.0.0.0"
+		PROXY_PORT = 0
+		profile.set_preference("network.proxy.type", 1)
+		profile.set_preference("network.proxy.socks", SOCKS5_PROXY_HOST)
+		profile.set_preference("network.proxy.socks_port", PROXY_PORT)
+		profile.set_preference("network.proxy.socks_remote_dns", True)
+		profile.set_preference("network.proxy.socks_version", 5)
+		profile.set_preference("network.proxy.no_proxies_on", "localhost, 10.20.30.40")
+		USER_AGENT = "Mozilla/5.0 ..."
+		profile.set_preference("general.useragent.override", USER_AGENT)
+		start_firefox(profile=profile)
+
+
 	On shutdown of the Python interpreter, Helium cleans up all resources used
 	for controlling the browser (such as the geckodriver process), but does
 	not close the browser itself. If you want to terminate the browser at the
@@ -119,7 +138,7 @@ def start_firefox(url=None, headless=False, options=None):
 
 		kill_browser()
 	"""
-	return _get_api_impl().start_firefox_impl(url, headless, options)
+	return _get_api_impl().start_firefox_impl(url, headless, options, profile)
 
 def go_to(url):
 	"""

--- a/helium/__init__.py
+++ b/helium/__init__.py
@@ -58,6 +58,7 @@ def start_chrome(
 		from selenium.webdriver import ChromeOptions
 		options = ChromeOptions()
 		options.add_argument('--proxy-server=1.2.3.4:5678')
+		options.add_extension('/absolute/path/to/extension/noscript-chrome.zip')
 		start_chrome(options=options)
 
 		from selenium.webdriver import DesiredCapabilities
@@ -77,7 +78,7 @@ def start_chrome(
 		url, headless, maximize, options, capabilities
 	)
 
-def start_firefox(url=None, headless=False, options=None, profile=None):
+def start_firefox(url=None, headless=False, options=None, profile=None, addons=None):
 	"""
 	:param url: URL to open.
 	:type url: str
@@ -87,6 +88,8 @@ def start_firefox(url=None, headless=False, options=None, profile=None):
 	:type options: :py:class:`selenium.webdriver.FirefoxOptions`
 	:param profile: FirefoxProfile to use for starting the browser.
 	:type profile: :py:class:`selenium.webdriver.FirefoxProfile`
+	:param addons: List of absolute paths to Firefox addons (.xpi files) to install
+	:type addons: list
 
 	Starts an instance of Firefox::
 
@@ -129,6 +132,14 @@ def start_firefox(url=None, headless=False, options=None, profile=None):
 		USER_AGENT = "Mozilla/5.0 ..."
 		profile.set_preference("general.useragent.override", USER_AGENT)
 		start_firefox(profile=profile)
+	
+	To install addons (such as uBlock and NoScript in the example), use the `addons` parameter::
+
+		extensions = [
+			'/absolute/path/to/addon/uBlock.xpi',
+			'/absolute/path/to/addon/noscript.xpi'
+		]
+		start_firefox(addons=extensions)
 
 
 	On shutdown of the Python interpreter, Helium cleans up all resources used

--- a/helium/_impl/__init__.py
+++ b/helium/_impl/__init__.py
@@ -74,8 +74,11 @@ class APIImpl:
 		" * set_driver(...)"
 	def __init__(self):
 		self.driver = None
-	def start_firefox_impl(self, url=None, headless=False, options=None, profile=None):
+	def start_firefox_impl(self, url=None, headless=False, options=None, profile=None, addons=None):
 		firefox_driver = self._start_firefox_driver(headless, options, profile)
+		if not addons is None:
+			for addon in addons:
+				firefox_driver.install_addon(addon)
 		return self._start(firefox_driver, url)
 	def _start_firefox_driver(self, headless, options, profile):
 		firefox_options = FirefoxOptions() if options is None else options

--- a/helium/_impl/__init__.py
+++ b/helium/_impl/__init__.py
@@ -16,7 +16,7 @@ from selenium.common.exceptions import UnexpectedAlertPresentException, \
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support.ui import Select
-from selenium.webdriver import Chrome, ChromeOptions, Firefox, FirefoxOptions
+from selenium.webdriver import Chrome, ChromeOptions, Firefox, FirefoxOptions, FirefoxProfile
 from time import sleep, time
 
 import atexit
@@ -74,15 +74,17 @@ class APIImpl:
 		" * set_driver(...)"
 	def __init__(self):
 		self.driver = None
-	def start_firefox_impl(self, url=None, headless=False, options=None):
-		firefox_driver = self._start_firefox_driver(headless, options)
+	def start_firefox_impl(self, url=None, headless=False, options=None, profile=None):
+		firefox_driver = self._start_firefox_driver(headless, options, profile)
 		return self._start(firefox_driver, url)
-	def _start_firefox_driver(self, headless, options):
+	def _start_firefox_driver(self, headless, options, profile):
 		firefox_options = FirefoxOptions() if options is None else options
+		firefox_profile = FirefoxProfile() if profile is None else profile
 		if headless:
 			firefox_options.headless = True
 		kwargs = {
 			'options': firefox_options,
+			'firefox_profile': firefox_profile,
 			'service_log_path': 'nul' if is_windows() else '/dev/null'
 		}
 		try:


### PR DESCRIPTION
Added the ability to install browser extensions when starting up Firefox.
Example also added in start_firefox for installing `uBlock` and `NoScript` addons.

Also added a quick example for adding extensions when using Chrome with `options.add_extension`